### PR TITLE
Remove extra stuff from file name.

### DIFF
--- a/main.js
+++ b/main.js
@@ -61,7 +61,7 @@ Thumbnail.prototype.ensureThumbnail = function ensureThumbnail(filename, width, 
   if (height) { wxh = 'x'+height; }
   if (width) { wxh = width + wxh; }
 
-  var thumbFilename = path.basename(filename, extension)+'-'+wxh+extension;
+  var thumbFilename = path.basename(filename, extension);
 
   var that = this;
 


### PR DESCRIPTION
This extra data makes it hard to work with the thumbnails as it's referenced to the original image.  We should just be able to add what we need to designate the thumbnail.